### PR TITLE
Add roots cache and augment our merkle module trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,5 +4,6 @@ members = [
 	"runtime",
 	"pallets/clsag",
 	"pallets/merkle",
+	"pallets/mixer",
 	"client"
 ]

--- a/pallets/merkle/Cargo.toml
+++ b/pallets/merkle/Cargo.toml
@@ -1,22 +1,22 @@
 [package]
-authors = ['Substrate DevHub <https://github.com/substrate-developer-hub>']
-description = 'FRAME pallet template for defining custom runtime logic.'
-edition = '2018'
-homepage = 'https://substrate.dev'
-license = 'Unlicense'
-name = 'pallet-merkle'
-repository = 'https://github.com/substrate-developer-hub/substrate-node-template/'
-version = '2.0.0'
+authors = ["Drew Stone <drew@commonwealth.im>, Filip Lazovic"]
+description = "Merkle tree membership pallet with zero-knowledge membership proof verification"
+edition = "2018"
+homepage = "https://substrate.dev"
+license = "Unlicense"
+name = "pallet-merkle"
+repository = "https://github.com/substrate-developer-hub/substrate-node-template/"
+version = "2.0.0"
 
 [package.metadata.docs.rs]
-targets = ['x86_64-unknown-linux-gnu']
+targets = ["x86_64-unknown-linux-gnu"]
 
 # alias "parity-scale-code" to "codec"
 [dependencies.codec]
 default-features = false
-features = ['derive']
-package = 'parity-scale-codec'
-version = '1.3.4'
+features = ["derive"]
+package = "parity-scale-codec"
+version = "1.3.4"
 
 [dependencies.curve25519-dalek]
 version = "3.0.0"
@@ -28,26 +28,27 @@ version = "0.1.5"
 
 [dependencies]
 balances = { version = "2.0.0", default-features = false, package = "pallet-balances" }
-frame-support = { default-features = false, version = '2.0.0' }
-frame-system = { default-features = false, version = '2.0.0' }
+frame-support = { default-features = false, version = "2.0.0" }
+frame-system = { default-features = false, version = "2.0.0" }
 sp-std = { default-features = false, version = "2.0.0" }
 merlin = { version = "2.0.0", default-features = false }
 sha2 = { version = "0.9.1", default-features = false }
-sp-runtime = { default-features = false, version = '2.0.0' }
+sp-runtime = { default-features = false, version = "2.0.0" }
 rand_core = { version = "0.5", default-features = false, features = ["alloc", "getrandom"] }
 bulletproofs = { version = "2.0.0", rev = "9ed295f", git = "https://github.com/edgeware-builders/bulletproofs", default-features = false, features = ["yoloproofs"] }
 rand = { version = "0.7", optional = true }
 
 [dev-dependencies]
-sp-core = { default-features = false, version = '2.0.0' }
-sp-io = { default-features = false, version = '2.0.0' }
+sp-core = { default-features = false, version = "2.0.0" }
+sp-io = { default-features = false, version = "2.0.0" }
 
 [features]
-default = ['std']
+default = ["std", "verify"]
+verify = []
 std = [
-    'codec/std',
-    'frame-support/std',
-    'frame-system/std',
+    "codec/std",
+    "frame-support/std",
+    "frame-system/std",
     "rand/std",
     "rand"
 ]

--- a/pallets/merkle/src/lib.rs
+++ b/pallets/merkle/src/lib.rs
@@ -206,7 +206,6 @@ decl_module! {
 		/// modules should use the module functions to verify and execute further
 		/// logic.
 		#[weight = 0]
-		#[cfg(feature="verify")]
 		pub fn verify(origin, group_id: T::GroupId, leaf: Data, path: Vec<(bool, Data)>) -> dispatch::DispatchResult {
 			let tree = <Groups<T>>::get(group_id)
 				.ok_or(Error::<T>::GroupDoesntExist)
@@ -249,7 +248,6 @@ decl_module! {
 		/// modules should use the module functions to verify and execute further
 		/// logic.
 		#[weight = 0]
-		#[cfg(feature="verify")]
 		pub fn verify_zk_membership_proof(
 			origin,
 			group_id: T::GroupId,
@@ -279,7 +277,6 @@ decl_module! {
 		/// modules should use the module functions to verify and execute further
 		/// logic.
 		#[weight = 0]
-		#[cfg(feature="verify")]
 		pub fn verify_zk_membership_proof_with_cache(
 			origin,
 			old_block: T::BlockNumber,

--- a/pallets/merkle/src/lib.rs
+++ b/pallets/merkle/src/lib.rs
@@ -148,8 +148,36 @@ decl_module! {
 		fn deposit_event() = default;
 
 		#[weight = 0]
+		pub fn set_manager_required(origin, group_id: T::GroupId, manager_required: bool) -> dispatch::DispatchResult {
+			let sender = ensure_signed(origin)?;
+
+			let mut tree = <Groups<T>>::get(group_id)
+				.ok_or(Error::<T>::GroupDoesntExist)
+				.unwrap();
+			// Changing manager required should always require an extrinsic from the manager even
+			// if the group doesn't explicitly require managers for other calls.
+			ensure!(sender == tree.manager, Error::<T>::ManagerIsRequired);
+			tree.requires_is_manager = manager_required;
+			Ok(())
+		}
+
+		#[weight = 0]
+		pub fn set_manager(origin, group_id: T::GroupId, new_manager: T::AccountId) -> dispatch::DispatchResult {
+			let sender = ensure_signed(origin)?;
+
+			let mut tree = <Groups<T>>::get(group_id)
+				.ok_or(Error::<T>::GroupDoesntExist)
+				.unwrap();
+			// Changing manager should always require an extrinsic from the manager even
+			// if the group doesn't explicitly require managers for other calls.
+			ensure!(sender == tree.manager, Error::<T>::ManagerIsRequired);
+			
+			tree.manager = new_manager;
+			Ok(())
+		}
+
+		#[weight = 0]
 		pub fn add_members(origin, group_id: T::GroupId, data_points: Vec<Data>) -> dispatch::DispatchResult {
-			// Check it was signed and get the signer. See also: ensure_root and ensure_none
 			let sender = ensure_signed(origin)?;
 
 			let mut tree = <Groups<T>>::get(group_id)

--- a/pallets/merkle/src/lib.rs
+++ b/pallets/merkle/src/lib.rs
@@ -155,6 +155,8 @@ decl_module! {
 			let mut tree = <Groups<T>>::get(group_id)
 				.ok_or(Error::<T>::GroupDoesntExist)
 				.unwrap();
+			// Check if the tree requires extrinsics to be called from a manager
+			ensure!(Self::is_manager_required(sender.clone(), &tree), Error::<T>::ManagerIsRequired);
 			let num_points = data_points.len() as u32;
 			ensure!(tree.leaf_count + num_points <= tree.max_leaves, Error::<T>::ExceedsMaxDepth);
 

--- a/pallets/merkle/src/mock.rs
+++ b/pallets/merkle/src/mock.rs
@@ -56,6 +56,7 @@ parameter_types! {
 	pub const MaxLocks: u32 = 50;
 	pub const MaxTreeDepth: u8 = 32;
 	pub const CacheBlockLength: u64 = 100;
+	pub const MinimumDepositLength: u64 = 10;
 }
 
 impl balances::Trait for Test {
@@ -73,6 +74,7 @@ impl Trait for Test {
 	type GroupId = u32;
 	type MaxTreeDepth = MaxTreeDepth;
 	type CacheBlockLength = CacheBlockLength;
+	type MinimumDepositLength = MinimumDepositLength;
 }
 
 pub type System = system::Module<Test>;

--- a/pallets/merkle/src/mock.rs
+++ b/pallets/merkle/src/mock.rs
@@ -45,19 +45,21 @@ impl frame_system::Trait for Test {
 	type MaximumBlockLength = MaximumBlockLength;
 	type Version = ();
 	type PalletInfo = ();
-	type AccountData = balances::AccountData<u128>;
+	type AccountData = balances::AccountData<Balance>;
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type SystemWeightInfo = ();
 }
 
 parameter_types! {
-	pub const ExistentialDeposit: u128 = 0;
+	pub const ExistentialDeposit: Balance = 0;
 	pub const MaxLocks: u32 = 50;
+	pub const MaxTreeDepth: u8 = 32;
+	pub const CacheBlockLength: u64 = 100;
 }
 
 impl balances::Trait for Test {
-	type Balance = u128;
+	type Balance = Balance;
 	type Event = ();
 	type DustRemoval = ();
 	type ExistentialDeposit = ExistentialDeposit;
@@ -68,6 +70,9 @@ impl balances::Trait for Test {
 
 impl Trait for Test {
 	type Event = ();
+	type GroupId = u32;
+	type MaxTreeDepth = MaxTreeDepth;
+	type CacheBlockLength = CacheBlockLength;
 }
 
 pub type System = system::Module<Test>;

--- a/pallets/merkle/src/mock.rs
+++ b/pallets/merkle/src/mock.rs
@@ -74,7 +74,6 @@ impl Trait for Test {
 	type GroupId = u32;
 	type MaxTreeDepth = MaxTreeDepth;
 	type CacheBlockLength = CacheBlockLength;
-	type MinimumDepositLength = MinimumDepositLength;
 }
 
 pub type System = system::Module<Test>;

--- a/pallets/merkle/src/tests.rs
+++ b/pallets/merkle/src/tests.rs
@@ -35,6 +35,91 @@ fn can_create_group() {
 }
 
 #[test]
+fn can_update_manager_when_required() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(MerkleGroups::create_group(
+			Origin::signed(1),
+			true,
+			Some(3),
+		));
+
+		assert_ok!(MerkleGroups::set_manager(
+			Origin::signed(1),
+			0,
+			2,
+		));
+	});
+}
+
+#[test]
+fn can_update_manager_when_not_required() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(MerkleGroups::create_group(
+			Origin::signed(1),
+			false,
+			Some(3),
+		));
+
+		assert_ok!(MerkleGroups::set_manager(
+			Origin::signed(1),
+			0,
+			2,
+		));
+	});
+}
+
+#[test]
+fn cannot_update_manager_as_not_manager() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(MerkleGroups::create_group(
+			Origin::signed(1),
+			false,
+			Some(3),
+		));
+
+		assert_err!(MerkleGroups::set_manager(
+			Origin::signed(2),
+			0,
+			2,
+		), Error::<Test>::ManagerIsRequired);
+	});
+}
+
+#[test]
+fn can_update_manager_required_manager() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(MerkleGroups::create_group(
+			Origin::signed(1),
+			false,
+			Some(3),
+		));
+
+		assert_ok!(MerkleGroups::set_manager_required(
+			Origin::signed(1),
+			0,
+			true,
+		));
+	});
+}
+
+#[test]
+fn cannot_update_manager_required_as_not_manager() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(MerkleGroups::create_group(
+			Origin::signed(1),
+			false,
+			Some(3),
+		));
+
+		assert_err!(MerkleGroups::set_manager_required(
+			Origin::signed(2),
+			0,
+			true,
+		), Error::<Test>::ManagerIsRequired);
+	});
+}
+
+#[test]
 fn can_add_member() {
 	new_test_ext().execute_with(|| {
 		let key = Data::from(key_bytes(1));

--- a/pallets/merkle/src/tests.rs
+++ b/pallets/merkle/src/tests.rs
@@ -53,6 +53,42 @@ fn can_add_member() {
 }
 
 #[test]
+fn can_add_member_as_manager() {
+	new_test_ext().execute_with(|| {
+		let key = Data::from(key_bytes(1));
+
+		assert_ok!(MerkleGroups::create_group(
+			Origin::signed(1),
+			true,
+			Some(3),
+		));
+		assert_ok!(MerkleGroups::add_members(
+			Origin::signed(1),
+			0,
+			vec![key.clone()]
+		));
+	});
+}
+
+#[test]
+fn cannot_add_member_as_not_manager() {
+	new_test_ext().execute_with(|| {
+		let key = Data::from(key_bytes(1));
+
+		assert_ok!(MerkleGroups::create_group(
+			Origin::signed(1),
+			true,
+			Some(3),
+		));
+		assert_err!(MerkleGroups::add_members(
+			Origin::signed(2),
+			0,
+			vec![key.clone()]
+		), Error::<Test>::ManagerIsRequired);
+	});
+}
+
+#[test]
 fn should_not_have_0_depth() {
 	new_test_ext().execute_with(|| {
 		assert_err!(

--- a/pallets/merkle/src/tests.rs
+++ b/pallets/merkle/src/tests.rs
@@ -28,7 +28,7 @@ fn can_create_group() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(MerkleGroups::create_group(
 			Origin::signed(1),
-			Some(10),
+			false,
 			Some(3),
 		));
 	});
@@ -41,7 +41,7 @@ fn can_add_member() {
 
 		assert_ok!(MerkleGroups::create_group(
 			Origin::signed(1),
-			Some(10),
+			false,
 			Some(3),
 		));
 		assert_ok!(MerkleGroups::add_members(
@@ -56,7 +56,7 @@ fn can_add_member() {
 fn should_not_have_0_depth() {
 	new_test_ext().execute_with(|| {
 		assert_err!(
-			MerkleGroups::create_group(Origin::signed(1), Some(10), Some(0)),
+			MerkleGroups::create_group(Origin::signed(1), false, Some(0)),
 			Error::<Test>::InvalidTreeDepth,
 		);
 	});
@@ -68,7 +68,7 @@ fn should_have_min_depth() {
 		let key = Data::from(key_bytes(1));
 		assert_ok!(MerkleGroups::create_group(
 			Origin::signed(1),
-			Some(10),
+			false,
 			Some(1),
 		));
 
@@ -89,7 +89,7 @@ fn should_have_max_depth() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(MerkleGroups::create_group(
 			Origin::signed(1),
-			Some(10),
+			false,
 			Some(32),
 		));
 	});
@@ -99,7 +99,7 @@ fn should_have_max_depth() {
 fn should_not_have_more_than_max_depth() {
 	new_test_ext().execute_with(|| {
 		assert_err!(
-			MerkleGroups::create_group(Origin::signed(1), Some(10), Some(33),),
+			MerkleGroups::create_group(Origin::signed(1), false, Some(33),),
 			Error::<Test>::InvalidTreeDepth,
 		);
 	});
@@ -115,7 +115,7 @@ fn should_have_correct_root_hash_after_insertion() {
 
 		assert_ok!(MerkleGroups::create_group(
 			Origin::signed(1),
-			Some(10),
+			false,
 			Some(2),
 		));
 		assert_ok!(MerkleGroups::add_members(
@@ -171,7 +171,7 @@ fn should_have_correct_root_hash() {
 
 		assert_ok!(MerkleGroups::create_group(
 			Origin::signed(1),
-			Some(10),
+			false,
 			Some(4),
 		));
 
@@ -214,7 +214,7 @@ fn should_be_unable_to_pass_proof_path_with_invalid_length() {
 		let key2 = Data::from(key_bytes(2));
 		assert_ok!(MerkleGroups::create_group(
 			Origin::signed(1),
-			Some(10),
+			false,
 			Some(2),
 		));
 		assert_ok!(MerkleGroups::add_members(
@@ -247,7 +247,7 @@ fn should_not_verify_invalid_proof() {
 
 		assert_ok!(MerkleGroups::create_group(
 			Origin::signed(1),
-			Some(10),
+			false,
 			Some(2),
 		));
 		assert_ok!(MerkleGroups::add_members(
@@ -294,7 +294,7 @@ fn should_verify_proof_of_membership() {
 
 		assert_ok!(MerkleGroups::create_group(
 			Origin::signed(1),
-			Some(10),
+			false,
 			Some(4),
 		));
 
@@ -376,7 +376,7 @@ fn should_verify_simple_zk_proof_of_membership() {
 
 		assert_ok!(MerkleGroups::create_group(
 			Origin::signed(1),
-			Some(10),
+			false,
 			Some(1),
 		));
 		assert_ok!(MerkleGroups::add_members(Origin::signed(1), 0, vec![leaf]));
@@ -420,7 +420,7 @@ fn should_not_use_nullifier_more_than_once() {
 
 		assert_ok!(MerkleGroups::create_group(
 			Origin::signed(1),
-			Some(10),
+			false,
 			Some(1),
 		));
 		assert_ok!(MerkleGroups::add_members(Origin::signed(1), 0, vec![leaf]));
@@ -476,7 +476,7 @@ fn should_not_verify_invalid_commitments_for_leaf_creation() {
 
 		assert_ok!(MerkleGroups::create_group(
 			Origin::signed(1),
-			Some(10),
+			false,
 			Some(1),
 		));
 		assert_ok!(MerkleGroups::add_members(Origin::signed(1), 0, vec![leaf]));
@@ -523,7 +523,7 @@ fn should_not_verify_invalid_commitments_for_membership() {
 
 		assert_ok!(MerkleGroups::create_group(
 			Origin::signed(1),
-			Some(10),
+			false,
 			Some(1),
 		));
 		assert_ok!(MerkleGroups::add_members(Origin::signed(1), 0, vec![leaf]));
@@ -568,7 +568,7 @@ fn should_not_verify_invalid_transcript() {
 
 		assert_ok!(MerkleGroups::create_group(
 			Origin::signed(1),
-			Some(10),
+			false,
 			Some(1),
 		));
 		assert_ok!(MerkleGroups::add_members(Origin::signed(1), 0, vec![leaf]));
@@ -620,7 +620,7 @@ fn should_verify_zk_proof_of_membership() {
 
 		assert_ok!(MerkleGroups::create_group(
 			Origin::signed(1),
-			Some(10),
+			false,
 			Some(3),
 		));
 		assert_ok!(MerkleGroups::add_members(
@@ -685,7 +685,7 @@ fn should_verify_large_zk_proof_of_membership() {
 
 		assert_ok!(MerkleGroups::create_group(
 			Origin::signed(1),
-			Some(10),
+			false,
 			Some(32),
 		));
 		assert_ok!(MerkleGroups::add_members(Origin::signed(1), 0, vec![leaf]));

--- a/pallets/merkle/src/tests.rs
+++ b/pallets/merkle/src/tests.rs
@@ -1,5 +1,5 @@
 // Tests to be written here
-
+use super::*;
 use crate::merkle::hasher::Hasher;
 use crate::merkle::helper::{commit_leaf, commit_path_level, leaf_data};
 use crate::merkle::keys::{Commitment, Data};
@@ -57,7 +57,7 @@ fn should_not_have_0_depth() {
 	new_test_ext().execute_with(|| {
 		assert_err!(
 			MerkleGroups::create_group(Origin::signed(1), Some(10), Some(0)),
-			"Invalid tree depth."
+			Error::<Test>::InvalidTreeDepth,
 		);
 	});
 }
@@ -79,7 +79,7 @@ fn should_have_min_depth() {
 		));
 		assert_err!(
 			MerkleGroups::add_members(Origin::signed(1), 0, vec![key.clone()]),
-			"Exceeded maximum tree depth."
+			Error::<Test>::ExceedsMaxDepth,
 		);
 	});
 }
@@ -100,22 +100,7 @@ fn should_not_have_more_than_max_depth() {
 	new_test_ext().execute_with(|| {
 		assert_err!(
 			MerkleGroups::create_group(Origin::signed(1), Some(10), Some(33),),
-			"Invalid tree depth."
-		);
-	});
-}
-
-#[test]
-fn should_not_use_existing_group_id() {
-	new_test_ext().execute_with(|| {
-		assert_ok!(MerkleGroups::create_group(
-			Origin::signed(1),
-			Some(10),
-			Some(3),
-		));
-		assert_err!(
-			MerkleGroups::create_group(Origin::signed(1), Some(10), Some(3),),
-			"Group already exists."
+			Error::<Test>::InvalidTreeDepth,
 		);
 	});
 }
@@ -241,13 +226,13 @@ fn should_be_unable_to_pass_proof_path_with_invalid_length() {
 		let path = vec![(true, key0)];
 		assert_err!(
 			MerkleGroups::verify(Origin::signed(2), 0, key0, path),
-			"Invalid path length."
+			Error::<Test>::InvalidPathLength,
 		);
 
 		let path = vec![(true, key0), (false, key1), (true, key2)];
 		assert_err!(
 			MerkleGroups::verify(Origin::signed(2), 0, key0, path),
-			"Invalid path length."
+			Error::<Test>::InvalidPathLength,
 		);
 	});
 }
@@ -279,21 +264,21 @@ fn should_not_verify_invalid_proof() {
 
 		assert_err!(
 			MerkleGroups::verify(Origin::signed(2), 0, key0, path),
-			"Invalid proof of membership."
+			Error::<Test>::InvalidMembershipProof,
 		);
 
 		let path = vec![(true, key1), (false, keyh2)];
 
 		assert_err!(
 			MerkleGroups::verify(Origin::signed(2), 0, key0, path),
-			"Invalid proof of membership."
+			Error::<Test>::InvalidMembershipProof,
 		);
 
 		let path = vec![(true, key2), (true, keyh1)];
 
 		assert_err!(
 			MerkleGroups::verify(Origin::signed(2), 0, key0, path),
-			"Invalid proof of membership."
+			Error::<Test>::InvalidMembershipProof,
 		);
 	});
 }
@@ -471,7 +456,7 @@ fn should_not_use_nullifier_more_than_once() {
 				Data(nullifier),
 				proof.to_bytes(),
 			),
-			"Nullifier already used."
+			Error::<Test>::AlreadyUsedNullifier,
 		);
 	});
 }
@@ -518,7 +503,7 @@ fn should_not_verify_invalid_commitments_for_leaf_creation() {
 				Data(nullifier),
 				proof.to_bytes(),
 			),
-			"Invalid proof of membership or leaf creation."
+			Error::<Test>::ZkVericationFailed,
 		);
 	});
 }
@@ -563,7 +548,7 @@ fn should_not_verify_invalid_commitments_for_membership() {
 				Data(nullifier),
 				proof.to_bytes(),
 			),
-			"Invalid proof of membership or leaf creation."
+			Error::<Test>::ZkVericationFailed,
 		);
 	});
 }
@@ -609,7 +594,7 @@ fn should_not_verify_invalid_transcript() {
 				Data(nullifier),
 				proof.to_bytes(),
 			),
-			"Invalid proof of membership or leaf creation."
+			Error::<Test>::ZkVericationFailed,
 		);
 	});
 }

--- a/pallets/merkle/src/tests.rs
+++ b/pallets/merkle/src/tests.rs
@@ -28,7 +28,6 @@ fn can_create_group() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(MerkleGroups::create_group(
 			Origin::signed(1),
-			0,
 			Some(10),
 			Some(3),
 		));
@@ -42,7 +41,6 @@ fn can_add_member() {
 
 		assert_ok!(MerkleGroups::create_group(
 			Origin::signed(1),
-			0,
 			Some(10),
 			Some(3),
 		));
@@ -58,7 +56,7 @@ fn can_add_member() {
 fn should_not_have_0_depth() {
 	new_test_ext().execute_with(|| {
 		assert_err!(
-			MerkleGroups::create_group(Origin::signed(1), 0, Some(10), Some(0),),
+			MerkleGroups::create_group(Origin::signed(1), Some(10), Some(0)),
 			"Invalid tree depth."
 		);
 	});
@@ -70,7 +68,6 @@ fn should_have_min_depth() {
 		let key = Data::from(key_bytes(1));
 		assert_ok!(MerkleGroups::create_group(
 			Origin::signed(1),
-			0,
 			Some(10),
 			Some(1),
 		));
@@ -92,7 +89,6 @@ fn should_have_max_depth() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(MerkleGroups::create_group(
 			Origin::signed(1),
-			0,
 			Some(10),
 			Some(32),
 		));
@@ -103,7 +99,7 @@ fn should_have_max_depth() {
 fn should_not_have_more_than_max_depth() {
 	new_test_ext().execute_with(|| {
 		assert_err!(
-			MerkleGroups::create_group(Origin::signed(1), 0, Some(10), Some(33),),
+			MerkleGroups::create_group(Origin::signed(1), Some(10), Some(33),),
 			"Invalid tree depth."
 		);
 	});
@@ -114,12 +110,11 @@ fn should_not_use_existing_group_id() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(MerkleGroups::create_group(
 			Origin::signed(1),
-			0,
 			Some(10),
 			Some(3),
 		));
 		assert_err!(
-			MerkleGroups::create_group(Origin::signed(1), 0, Some(10), Some(3),),
+			MerkleGroups::create_group(Origin::signed(1), Some(10), Some(3),),
 			"Group already exists."
 		);
 	});
@@ -135,7 +130,6 @@ fn should_have_correct_root_hash_after_insertion() {
 
 		assert_ok!(MerkleGroups::create_group(
 			Origin::signed(1),
-			0,
 			Some(10),
 			Some(2),
 		));
@@ -192,7 +186,6 @@ fn should_have_correct_root_hash() {
 
 		assert_ok!(MerkleGroups::create_group(
 			Origin::signed(1),
-			0,
 			Some(10),
 			Some(4),
 		));
@@ -236,7 +229,6 @@ fn should_be_unable_to_pass_proof_path_with_invalid_length() {
 		let key2 = Data::from(key_bytes(2));
 		assert_ok!(MerkleGroups::create_group(
 			Origin::signed(1),
-			0,
 			Some(10),
 			Some(2),
 		));
@@ -270,7 +262,6 @@ fn should_not_verify_invalid_proof() {
 
 		assert_ok!(MerkleGroups::create_group(
 			Origin::signed(1),
-			0,
 			Some(10),
 			Some(2),
 		));
@@ -318,7 +309,6 @@ fn should_verify_proof_of_membership() {
 
 		assert_ok!(MerkleGroups::create_group(
 			Origin::signed(1),
-			0,
 			Some(10),
 			Some(4),
 		));
@@ -401,7 +391,6 @@ fn should_verify_simple_zk_proof_of_membership() {
 
 		assert_ok!(MerkleGroups::create_group(
 			Origin::signed(1),
-			0,
 			Some(10),
 			Some(1),
 		));
@@ -446,7 +435,6 @@ fn should_not_use_nullifier_more_than_once() {
 
 		assert_ok!(MerkleGroups::create_group(
 			Origin::signed(1),
-			0,
 			Some(10),
 			Some(1),
 		));
@@ -503,7 +491,6 @@ fn should_not_verify_invalid_commitments_for_leaf_creation() {
 
 		assert_ok!(MerkleGroups::create_group(
 			Origin::signed(1),
-			0,
 			Some(10),
 			Some(1),
 		));
@@ -551,7 +538,6 @@ fn should_not_verify_invalid_commitments_for_membership() {
 
 		assert_ok!(MerkleGroups::create_group(
 			Origin::signed(1),
-			0,
 			Some(10),
 			Some(1),
 		));
@@ -597,7 +583,6 @@ fn should_not_verify_invalid_transcript() {
 
 		assert_ok!(MerkleGroups::create_group(
 			Origin::signed(1),
-			0,
 			Some(10),
 			Some(1),
 		));
@@ -650,7 +635,6 @@ fn should_verify_zk_proof_of_membership() {
 
 		assert_ok!(MerkleGroups::create_group(
 			Origin::signed(1),
-			0,
 			Some(10),
 			Some(3),
 		));
@@ -716,7 +700,6 @@ fn should_verify_large_zk_proof_of_membership() {
 
 		assert_ok!(MerkleGroups::create_group(
 			Origin::signed(1),
-			0,
 			Some(10),
 			Some(32),
 		));

--- a/pallets/mixer/Cargo.toml
+++ b/pallets/mixer/Cargo.toml
@@ -32,7 +32,7 @@ frame-support = { default-features = false, version = '2.0.0' }
 frame-system = { default-features = false, version = '2.0.0' }
 sp-std = { default-features = false, version = "2.0.0" }
 sp-runtime = { default-features = false, version = '2.0.0' }
-pallet-merkle = { path = "../merkle" }
+pallet-merkle = { path = "../merkle", default-features = false}
 
 rand = { version = "0.7", optional = true }
 

--- a/pallets/mixer/Cargo.toml
+++ b/pallets/mixer/Cargo.toml
@@ -46,11 +46,6 @@ std = [
     'codec/std',
     'frame-support/std',
     'frame-system/std',
-    "merkle/std",
     "rand/std",
     "rand"
 ]
-
-[[bench]]
-name = "bench"
-harness = false

--- a/pallets/mixer/Cargo.toml
+++ b/pallets/mixer/Cargo.toml
@@ -1,0 +1,56 @@
+[package]
+authors = ['Drew Stone <drew@commonwealth.im>, Filip Lazovic']
+description = 'Pallet for mixing native assets in a zero-knowledge mixer'
+edition = '2018'
+homepage = 'https://substrate.dev'
+license = 'Unlicense'
+name = 'pallet-mixer'
+repository = 'https://github.com/substrate-developer-hub/substrate-node-template/'
+version = '2.0.0'
+
+[package.metadata.docs.rs]
+targets = ['x86_64-unknown-linux-gnu']
+
+# alias "parity-scale-code" to "codec"
+[dependencies.codec]
+default-features = false
+features = ['derive']
+package = 'parity-scale-codec'
+version = '1.3.4'
+
+[dependencies.curve25519-dalek]
+version = "3.0.0"
+default-features = false
+features = ["u64_backend", "alloc"]
+
+[dependencies.bencher]
+version = "0.1.5"
+
+[dependencies]
+balances = { version = "2.0.0", default-features = false, package = "pallet-balances" }
+frame-support = { default-features = false, version = '2.0.0' }
+frame-system = { default-features = false, version = '2.0.0' }
+sp-std = { default-features = false, version = "2.0.0" }
+sp-runtime = { default-features = false, version = '2.0.0' }
+pallet-merkle = { path = "../merkle" }
+
+rand = { version = "0.7", optional = true }
+
+[dev-dependencies]
+sp-core = { default-features = false, version = '2.0.0' }
+sp-io = { default-features = false, version = '2.0.0' }
+
+[features]
+default = ['std']
+std = [
+    'codec/std',
+    'frame-support/std',
+    'frame-system/std',
+    "merkle/std",
+    "rand/std",
+    "rand"
+]
+
+[[bench]]
+name = "bench"
+harness = false

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -272,7 +272,6 @@ impl clsag::Trait for Runtime {
 parameter_types! {
 	pub const MaxTreeDepth: u8 = 32;
 	pub const CacheBlockLength: BlockNumber = 100;
-	pub const MinimumDepositLength: BlockNumber = 10;
 }
 
 impl merkle::Trait for Runtime {
@@ -280,7 +279,6 @@ impl merkle::Trait for Runtime {
 	type GroupId = u32;
 	type MaxTreeDepth = MaxTreeDepth;
 	type CacheBlockLength = CacheBlockLength;
-	type MinimumDepositLength = MinimumDepositLength;
 }
 
 // Create the runtime by composing the FRAME pallets that were previously configured.

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -269,8 +269,18 @@ impl clsag::Trait for Runtime {
 	type Event = Event;
 }
 
+parameter_types! {
+	pub const MaxTreeDepth: u8 = 32;
+	pub const CacheBlockLength: BlockNumber = 100;
+	pub const MinimumDepositLength: BlockNumber = 10;
+}
+
 impl merkle::Trait for Runtime {
 	type Event = Event;
+	type GroupId = u32;
+	type MaxTreeDepth = MaxTreeDepth;
+	type CacheBlockLength = CacheBlockLength;
+	type MinimumDepositLength = MinimumDepositLength;
 }
 
 // Create the runtime by composing the FRAME pallets that were previously configured.


### PR DESCRIPTION
This PR adds a few items to our trait and adds caching of old merkle roots for reward payments.
- [x] Defines MinimumDepositLength to trait Config
- [x] Defines CacheBlockLength to trait Config
- [x] Adds double map `(block_number, group_id) => Vec<merkle_roots>` for cache storage
- [x] Adds onFinalize to cleanup old blocks once the cache length has exhausted older blocks/merkle root data
- [x] Adds new `verify_zk_membership_proof_with_rewards` that uses caching strategy.