### PR TITLE
Added zk prove/verify

### DIFF
--- a/client/src/main.rs
+++ b/client/src/main.rs
@@ -45,7 +45,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 	println!("create group {:?}", elapsed);
 	println!("");
 
-	let (leaf, _, leaf_com, path, s_com, nullifier, proof_bytes) = prove(&h);
+	let (leaf, _, zk_proof) = prove(&h);
 
 	// Add members
 	let start = Instant::now();
@@ -69,11 +69,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 			.verify_zk_membership_proof(
 				&signer,
 				group_id,
-				leaf_com,
-				path.clone(),
-				s_com,
-				nullifier,
-				proof_bytes.clone(),
+				zk_proof.leaf_com,
+				zk_proof.path.clone(),
+				zk_proof.r_com,
+				zk_proof.nullifier,
+				zk_proof.bytes.clone(),
 			)
 			.await?;
 		signer.increment_nonce();
@@ -83,11 +83,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 		.verify_zk_membership_proof_and_watch(
 			&signer,
 			num_groups,
-			leaf_com,
-			path,
-			s_com,
-			nullifier,
-			proof_bytes,
+			zk_proof.leaf_com,
+			zk_proof.path,
+			zk_proof.r_com,
+			zk_proof.nullifier,
+			zk_proof.bytes,
 		)
 		.await?;
 	verify_zk_txs.insert(format!("{:?}", res_zk.extrinsic));

--- a/pallets/merkle/benches/bench.rs
+++ b/pallets/merkle/benches/bench.rs
@@ -9,9 +9,9 @@ use bencher::Bencher;
 
 fn verify_32h_binary_poseidon(b: &mut Bencher) {
 	let poseidon = Poseidon::new(4);
-	let (_, lh, com_leaf, path, com_s, null, proof) = prove(&poseidon);
+	let (_, root, zk_proof) = prove(&poseidon);
 	b.bench_n(3, |new_b| {
-		new_b.iter(|| verify(&poseidon, lh, com_leaf, &path, com_s, null, &proof))
+		new_b.iter(|| verify(root, zk_proof.clone(), &poseidon))
 	});
 }
 

--- a/pallets/merkle/src/merkle/helper.rs
+++ b/pallets/merkle/src/merkle/helper.rs
@@ -1,7 +1,7 @@
 use crate::merkle::hasher::Hasher;
 use crate::merkle::keys::{Commitment, Data};
 use bulletproofs::r1cs::{
-	ConstraintSystem, LinearCombination, Prover, R1CSProof, Variable, Verifier,
+	ConstraintSystem, LinearCombination, Prover, R1CSError, R1CSProof, Variable, Verifier,
 };
 use bulletproofs::{BulletproofGens, PedersenGens};
 use curve25519_dalek::ristretto::CompressedRistretto;
@@ -9,6 +9,15 @@ use curve25519_dalek::scalar::Scalar;
 use merlin::Transcript;
 use rand_core::{CryptoRng, OsRng, RngCore};
 use sp_std::prelude::*;
+
+#[derive(Clone)]
+pub struct ZkProof {
+	pub leaf_com: Commitment,
+	pub path: Vec<(Commitment, Commitment)>,
+	pub r_com: Commitment,
+	pub nullifier: Data,
+	pub bytes: Vec<u8>,
+}
 
 /// A leaf in our system represents a commitment to a random number `r` and a random number `nullifier`
 pub fn leaf_data<H: Hasher, C: CryptoRng + RngCore>(rng: &mut C, h: &H) -> (Scalar, Scalar, Data) {
@@ -52,17 +61,28 @@ pub fn commit_path_level<H: Hasher, C: CryptoRng + RngCore>(
 	(com_bit, com_pair, hash_con)
 }
 
-pub fn prove<H: Hasher>(
+pub fn prove<H: Hasher>(h: &H) -> (Data, Data, ZkProof) {
+	let mut test_rng = OsRng;
+	let (r, nullifier, leaf) = leaf_data(&mut test_rng, h);
+	let mut path = Vec::new();
+	let mut hash = leaf;
+	for _ in 0..32 {
+		path.push((true, hash));
+		hash = Data::hash(hash, hash, h);
+	}
+	let zk_proof = prove_with_path(hash, leaf, nullifier, r, path, h);
+
+	(leaf, hash, zk_proof)
+}
+
+pub fn prove_with_path<H: Hasher>(
+	root: Data,
+	leaf: Data,
+	nullifier: Scalar,
+	r: Scalar,
+	path: Vec<(bool, Data)>,
 	h: &H,
-) -> (
-	Data,
-	Data,
-	Commitment,
-	Vec<(Commitment, Commitment)>,
-	Commitment,
-	Data,
-	Vec<u8>,
-) {
+) -> ZkProof {
 	let pc_gens = PedersenGens::default();
 	let bp_gens = BulletproofGens::new(4096, 1);
 
@@ -70,59 +90,50 @@ pub fn prove<H: Hasher>(
 	let mut prover = Prover::new(&pc_gens, &mut prover_transcript);
 
 	let mut test_rng = OsRng;
-	let (r, nullifier, leaf) = leaf_data(&mut test_rng, h);
-
-	let (r_com, leaf_com1, leaf_var1) =
+	let (r_com, leaf_com, leaf_var) =
 		commit_leaf(&mut test_rng, &mut prover, leaf, r, nullifier, h);
 
-	let mut lh = leaf;
-	let mut lh_lc: LinearCombination = leaf_var1.into();
-	let mut path = Vec::new();
-	for _ in 0..32 {
-		let (bit_com, leaf_com, node_con) =
-			commit_path_level(&mut test_rng, &mut prover, lh, lh_lc, 1, h);
-		lh_lc = node_con;
-		lh = Data::hash(lh, lh, h);
-		path.push((Commitment(bit_com), Commitment(leaf_com)));
+	let mut hash_lc: LinearCombination = leaf_var.into();
+	let mut zk_path = Vec::new();
+	for (side, node) in path {
+		let (bit_com, node_com, node_con) =
+			commit_path_level(&mut test_rng, &mut prover, node, hash_lc, side as u8, h);
+		hash_lc = node_con;
+		zk_path.push((Commitment(bit_com), Commitment(node_com)));
 	}
-	prover.constrain(lh_lc - lh.0);
+	prover.constrain(hash_lc - root.0);
 
 	let proof = prover.prove_with_rng(&bp_gens, &mut test_rng).unwrap();
 
-	(
-		leaf,
-		lh,
-		Commitment(leaf_com1),
-		path,
-		Commitment(r_com),
-		Data(nullifier),
-		proof.to_bytes(),
-	)
+	ZkProof {
+		leaf_com: Commitment(leaf_com),
+		path: zk_path,
+		r_com: Commitment(r_com),
+		nullifier: Data(nullifier),
+		bytes: proof.to_bytes(),
+	}
 }
 
-pub fn verify<H: Hasher>(
-	h: &H,
-	root_hash: Data,
-	leaf_com: Commitment,
-	path: &Vec<(Commitment, Commitment)>,
-	r_com: Commitment,
-	nullifier: Data,
-	proof_bytes: &Vec<u8>,
-) {
+pub fn verify<H: Hasher>(root_hash: Data, zk_proof: ZkProof, h: &H) -> Result<(), R1CSError> {
 	let pc_gens = PedersenGens::default();
 	let bp_gens = BulletproofGens::new(4096, 1);
 
 	let mut verifier_transcript = Transcript::new(b"zk_membership_proof");
 	let mut verifier = Verifier::new(&mut verifier_transcript);
 
-	let var_leaf = verifier.commit(leaf_com.0);
-	let var_s = verifier.commit(r_com.0);
-	let leaf_lc =
-		Data::constrain_verifier(&mut verifier, &pc_gens, var_s.into(), nullifier.0.into(), h);
+	let var_leaf = verifier.commit(zk_proof.leaf_com.0);
+	let var_s = verifier.commit(zk_proof.r_com.0);
+	let leaf_lc = Data::constrain_verifier(
+		&mut verifier,
+		&pc_gens,
+		var_s.into(),
+		zk_proof.nullifier.0.into(),
+		h,
+	);
 	verifier.constrain(leaf_lc - var_leaf);
 
 	let mut hash: LinearCombination = var_leaf.into();
-	for (bit, pair) in path {
+	for (bit, pair) in zk_proof.path {
 		let var_bit = verifier.commit(bit.0);
 		let var_pair = verifier.commit(pair.0);
 
@@ -133,10 +144,9 @@ pub fn verify<H: Hasher>(
 		hash = Data::constrain_verifier(&mut verifier, &pc_gens, left, right, h);
 	}
 	verifier.constrain(hash - root_hash.0);
-	let proof = R1CSProof::from_bytes(&proof_bytes).unwrap();
+	let proof = R1CSProof::from_bytes(&zk_proof.bytes).unwrap();
 
 	let mut rng = OsRng;
-	verifier
-		.verify_with_rng(&proof, &pc_gens, &bp_gens, &mut rng)
-		.unwrap();
+	let res = verifier.verify_with_rng(&proof, &pc_gens, &bp_gens, &mut rng);
+	res
 }

--- a/wasm-utils/Cargo.toml
+++ b/wasm-utils/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2018"
 wasm-bindgen = {version = "0.2.69", features = ["serde-serialize"]}
 curve25519-dalek = "3.0.0"
 pallet-merkle = { path = "../pallets/merkle" }
+rand_core = { version = "0.5", default-features = false, features = ["alloc", "getrandom"] }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/wasm-utils/src/lib.rs
+++ b/wasm-utils/src/lib.rs
@@ -1,5 +1,8 @@
+use curve25519_dalek::scalar::Scalar;
+use pallet_merkle::merkle::helper::{prove_with_path, verify, ZkProof};
 use pallet_merkle::merkle::keys::Data;
 use pallet_merkle::merkle::poseidon::Poseidon;
+use rand_core::OsRng;
 use std::collections::hash_map::HashMap;
 use wasm_bindgen::prelude::*;
 
@@ -24,6 +27,17 @@ pub fn set_panic_hook() {
 	console_error_panic_hook::set_once();
 }
 
+pub fn generate_secrets() -> (Scalar, Scalar) {
+	let mut rng = OsRng {};
+	(Scalar::random(&mut rng), Scalar::random(&mut rng))
+}
+
+pub struct LeafData {
+	index: usize,
+	r: Scalar,
+	nullifier: Scalar,
+}
+
 pub struct TreeState {
 	edge_nodes: Vec<Data>,
 	leaf_count: usize,
@@ -33,7 +47,7 @@ pub struct TreeState {
 pub struct MerkleClient {
 	curr_root: Data,
 	states: HashMap<Data, TreeState>,
-	leaf_indices: HashMap<Data, usize>,
+	saved_leafs: HashMap<Data, LeafData>,
 	levels: Vec<Vec<Data>>,
 	hasher: Poseidon,
 	max_leaves: u32,
@@ -54,7 +68,7 @@ impl MerkleClient {
 		Self {
 			curr_root: init_root,
 			states: init_states,
-			leaf_indices: HashMap::new(),
+			saved_leafs: HashMap::new(),
 			levels: vec![vec![Data::zero()]; num_levels],
 			hasher: Poseidon::new(4),
 			max_leaves: u32::MAX >> (max_levels - num_levels),
@@ -70,6 +84,22 @@ impl MerkleClient {
 }
 
 impl MerkleClient {
+	pub fn deposit(&mut self) -> [u8; 32] {
+		let (r, nullifier) = generate_secrets();
+		let leaf = Data::hash(Data(r), Data(nullifier), &self.hasher);
+		// TODO: send extrinsic to the chain,
+		// and listen to events to get the index of the added leaf
+		let state = self.states.get(&self.curr_root).unwrap();
+		let ld = LeafData {
+			r,
+			nullifier,
+			index: state.leaf_count,
+		};
+		self.saved_leafs.insert(leaf, ld);
+		self.add_leaf(leaf.0.to_bytes());
+		leaf.0.to_bytes()
+	}
+
 	pub fn add_leaf(&mut self, leaf: [u8; 32]) {
 		assert!(
 			self.levels[0].len() < self.max_leaves as usize,
@@ -108,7 +138,6 @@ impl MerkleClient {
 		}
 
 		self.curr_root = pair_hash;
-		self.leaf_indices.insert(data, curr_state.leaf_count);
 		self.states.insert(pair_hash, new_state);
 	}
 
@@ -116,11 +145,12 @@ impl MerkleClient {
 		let root = Data::from(root_bytes);
 		let leaf = Data::from(leaf_bytes);
 		assert!(self.states.contains_key(&root), "Root not found!");
-		assert!(self.leaf_indices.contains_key(&leaf), "Leaf not found!");
+		assert!(self.saved_leafs.contains_key(&leaf), "Leaf not found!");
 
 		let state = self.states.get(&root).unwrap();
 		let mut last_index = state.leaf_count - 1;
-		let mut node_index = self.leaf_indices.get(&leaf).cloned().unwrap();
+		let saved_leaf = self.saved_leafs.get(&leaf).unwrap();
+		let mut node_index = saved_leaf.index;
 
 		assert!(
 			node_index <= last_index,
@@ -128,8 +158,8 @@ impl MerkleClient {
 		);
 		let mut path = Vec::new();
 		for (i, level) in self.levels.iter().enumerate() {
-			let is_left = node_index % 2 == 0;
-			let node = match is_left {
+			let is_right = node_index % 2 == 0;
+			let node = match is_right {
 				true => {
 					if node_index == last_index {
 						state.edge_nodes[i]
@@ -140,7 +170,7 @@ impl MerkleClient {
 				false => level[node_index - 1],
 			};
 
-			path.push((is_left, node.0.to_bytes()));
+			path.push((is_right, node.0.to_bytes()));
 			node_index /= 2;
 			last_index /= 2;
 		}
@@ -167,6 +197,32 @@ impl MerkleClient {
 			}
 		}
 		root == hash
+	}
+
+	pub fn prove_zk(&self, root_bytes: [u8; 32], leaf_bytes: [u8; 32]) -> ZkProof {
+		let root = Data::from(root_bytes);
+		let leaf = Data::from(leaf_bytes);
+
+		assert!(self.saved_leafs.contains_key(&leaf), "Leaf not found!");
+		let ld = self.saved_leafs.get(&leaf).unwrap();
+
+		// First we create normal proof, then make zk proof against it
+		let path = self.prove(root_bytes, leaf_bytes);
+		let path_data: Vec<(bool, Data)> = path
+			.into_iter()
+			.map(|(side, d)| (side, Data::from(d)))
+			.collect();
+
+		let zk_proof = prove_with_path(root, leaf, ld.nullifier, ld.r, path_data, &self.hasher);
+
+		zk_proof
+	}
+
+	pub fn verify_zk(&self, root_bytes: [u8; 32], zk_proof: ZkProof) -> bool {
+		let root = Data::from(root_bytes);
+		let res = verify(root, zk_proof, &self.hasher);
+
+		res.is_ok()
 	}
 }
 
@@ -257,47 +313,31 @@ mod tests {
 	#[test]
 	fn should_make_correct_proof() {
 		let mut tree = MerkleClient::new(2);
-		let leaf1 = Data(Scalar::from(1u32));
-		let leaf2 = Data(Scalar::from(2u32));
-		let leaf3 = Data(Scalar::from(3u32));
+		let leaf1 = tree.deposit();
+		let leaf2 = tree.deposit();
+		let leaf3 = tree.deposit();
 
-		tree.add_leaf(leaf1.0.to_bytes());
-		let path = tree.prove(tree.curr_root.0.to_bytes(), leaf1.0.to_bytes());
-		let valid = tree.verify(
-			tree.curr_root.0.to_bytes(),
-			leaf1.0.to_bytes(),
-			path.clone(),
-		);
+		let path = tree.prove(tree.curr_root.0.to_bytes(), leaf1);
+		let valid = tree.verify(tree.curr_root.0.to_bytes(), leaf1, path.clone());
 		assert!(valid);
 
-		tree.add_leaf(leaf2.0.to_bytes());
-		let path = tree.prove(tree.curr_root.0.to_bytes(), leaf2.0.to_bytes());
-		let valid = tree.verify(
-			tree.curr_root.0.to_bytes(),
-			leaf2.0.to_bytes(),
-			path.clone(),
-		);
+		let path = tree.prove(tree.curr_root.0.to_bytes(), leaf2);
+		let valid = tree.verify(tree.curr_root.0.to_bytes(), leaf2, path.clone());
 		assert!(valid);
 
-		tree.add_leaf(leaf3.0.to_bytes());
-		let path = tree.prove(tree.curr_root.0.to_bytes(), leaf3.0.to_bytes());
-		let valid = tree.verify(
-			tree.curr_root.0.to_bytes(),
-			leaf3.0.to_bytes(),
-			path.clone(),
-		);
+		let path = tree.prove(tree.curr_root.0.to_bytes(), leaf3);
+		let valid = tree.verify(tree.curr_root.0.to_bytes(), leaf3, path.clone());
 		assert!(valid);
 	}
 
 	#[test]
 	fn should_not_verify_incorrect_proof() {
 		let mut tree = MerkleClient::new(2);
-		let leaf1 = Data(Scalar::from(1u32));
+		let leaf1 = tree.deposit();
 		let leaf2 = Data(Scalar::from(2u32));
 		let leaf3 = Data(Scalar::from(3u32));
 
-		tree.add_leaf(leaf1.0.to_bytes());
-		let path = tree.prove(tree.curr_root.0.to_bytes(), leaf1.0.to_bytes());
+		let path = tree.prove(tree.curr_root.0.to_bytes(), leaf1);
 		let valid = tree.verify(
 			tree.curr_root.0.to_bytes(),
 			leaf2.0.to_bytes(),
@@ -305,13 +345,23 @@ mod tests {
 		);
 		assert!(!valid);
 
-		tree.add_leaf(leaf2.0.to_bytes());
-		let path = tree.prove(tree.curr_root.0.to_bytes(), leaf1.0.to_bytes());
+		let path = tree.prove(tree.curr_root.0.to_bytes(), leaf1);
 		let valid = tree.verify(
 			tree.curr_root.0.to_bytes(),
 			leaf3.0.to_bytes(),
 			path.clone(),
 		);
 		assert!(!valid);
+	}
+
+	#[test]
+	fn should_make_correct_zk_proof() {
+		let mut tree = MerkleClient::new(2);
+
+		let leaf1 = tree.deposit();
+		tree.add_leaf(leaf1);
+		let proof = tree.prove_zk(tree.curr_root.0.to_bytes(), leaf1);
+		let valid = tree.verify_zk(tree.curr_root.0.to_bytes(), proof);
+		assert!(valid);
 	}
 }


### PR DESCRIPTION
To construct the zk proof, I'm reusing helper functions: https://github.com/edgeware-builders/anon/blob/web-client-rust-functions/pallets/merkle/src/merkle/helper.rs

We should modify those and turn them into gadgets, namely, we should be able to pass generators and prover/verifier instances, and rename them maybe