### PR TITLE
add transaction gadget and test

### DIFF
--- a/gadgets/src/lib.rs
+++ b/gadgets/src/lib.rs
@@ -4,3 +4,4 @@ pub mod poseidon;
 pub mod zero_nonzero;
 pub mod smt;
 pub mod utils;
+pub mod transaction;

--- a/gadgets/src/transaction/builder.rs
+++ b/gadgets/src/transaction/builder.rs
@@ -1,0 +1,45 @@
+use crate::poseidon::gen_mds_matrix;
+use crate::poseidon::gen_round_keys;
+use crate::poseidon::PoseidonBuilder;
+use crate::poseidon::sbox::PoseidonSbox;
+use crate::poseidon::builder::Poseidon;
+
+#[derive(Clone)]
+pub struct TransactionGadget {
+	hash_params: Poseidon,
+}
+
+pub struct TransactionGadgetBuilder {
+	hash_params: Option<Poseidon>,
+}
+
+impl TransactionGadgetBuilder {
+	pub fn new() -> Self {
+		Self {
+			hash_params: None,
+		}
+	}
+
+	pub fn hash_params(&mut self, hash_params: Poseidon) -> &mut Self {
+		self.hash_params = Some(hash_params);
+		self
+	}
+
+	pub fn build(&self) -> TransactionGadget {
+		let hash_params = self.hash_params.clone().unwrap_or_else(|| {
+			let width = 6;
+			let (full_b, full_e) = (4, 4);
+			let partial_rounds = 57;
+			PoseidonBuilder::new(width)
+				.num_rounds(full_b, full_e, partial_rounds)
+				.round_keys(gen_round_keys(width, full_b + full_e + partial_rounds))
+				.mds_matrix(gen_mds_matrix(width))
+				.sbox(PoseidonSbox::Inverse)
+				.build()
+		});
+
+		TransactionGadget {
+			hash_params,
+		}
+	}
+}

--- a/gadgets/src/transaction/mod.rs
+++ b/gadgets/src/transaction/mod.rs
@@ -144,7 +144,9 @@ pub fn transaction_preimage_gadget<CS: ConstraintSystem>(
 	for i in 0..transactions.len() {
 		let tx = &transactions[i];
 		tx.hash_constraints(cs, poseidon_params)?;
-		tx.non_zero_constraints(cs)?;		
+		// ensure all amounts are non-zero
+		tx.non_zero_constraints(cs)?;
+		// TODO: ensure all amounts are less than MAX number
 
 		sum_inputs = sum_inputs + tx.input_amount();
 		sum_outputs = sum_outputs + tx.output_amount();

--- a/gadgets/src/transaction/mod.rs
+++ b/gadgets/src/transaction/mod.rs
@@ -1,0 +1,156 @@
+#[cfg(test)]
+pub mod tests;
+
+
+pub mod builder;
+
+use crate::poseidon::Poseidon_hash_4_gadget;
+use crate::poseidon::Poseidon_hash_2_gadget;
+use crate::poseidon::Poseidon_hash_2;
+use crate::poseidon::Poseidon_hash_4;
+use crate::zero_nonzero::is_nonzero_gadget;
+
+use crate::poseidon::builder::Poseidon;
+use bulletproofs::r1cs::{ConstraintSystem, R1CSError};
+use curve25519_dalek::scalar::Scalar;
+
+
+use bulletproofs::r1cs::LinearCombination;
+use crate::utils::{AllocatedScalar};
+
+pub enum HashSize {
+	Two,
+	Four,
+}
+
+pub struct AllocatedCoin {
+	// private
+	inv_value: AllocatedScalar,
+	value: AllocatedScalar,
+	rho: AllocatedScalar,
+	r: AllocatedScalar,
+	nullifier: AllocatedScalar,
+	// public
+	sn: Scalar,
+	cm: Scalar,
+}
+
+impl AllocatedCoin {
+	pub fn new(
+		inv_value: AllocatedScalar,
+		value: AllocatedScalar,
+		rho: AllocatedScalar,
+		r: AllocatedScalar,
+		nullifier: AllocatedScalar,
+		sn: Scalar,
+		cm: Scalar,
+	) -> Self {
+		Self { inv_value, value, rho, r, nullifier, sn, cm }
+	}
+}
+
+pub struct Transaction {
+	pub inputs: Vec<AllocatedCoin>,
+	pub outputs: Vec<AllocatedCoin>,
+	pub statics_2: Vec<AllocatedScalar>,
+	pub statics_4: Vec<AllocatedScalar>,
+}
+
+impl Transaction {
+	fn hash_constraints<CS: ConstraintSystem>(&self, cs: &mut CS, poseidon_params: &Poseidon) -> Result<(), R1CSError>{
+		// check inputs
+		for i in 0..self.inputs.len() {
+			Poseidon_hash_2_gadget(
+				cs,
+				self.inputs[i].r,
+				self.inputs[i].nullifier,
+				self.statics_2.clone(),
+				poseidon_params,
+				&self.inputs[i].sn
+			)?;
+
+			Poseidon_hash_4_gadget(
+				cs,
+				[self.inputs[i].value, self.inputs[i].rho, self.inputs[i].r, self.inputs[i].nullifier].to_vec(),
+				self.statics_4.clone(),
+				poseidon_params,
+				&self.inputs[i].cm
+			)?;
+		}
+
+		// check outputs
+		for i in 0..self.outputs.len() {
+			Poseidon_hash_2_gadget(
+				cs,
+				self.outputs[i].r,
+				self.outputs[i].nullifier,
+				self.statics_2.clone(),
+				poseidon_params,
+				&self.outputs[i].sn
+			)?;
+
+			Poseidon_hash_4_gadget(
+				cs,
+				[self.outputs[i].value, self.outputs[i].rho, self.outputs[i].r, self.outputs[i].nullifier].to_vec(),
+				self.statics_4.clone(),
+				poseidon_params,
+				&self.outputs[i].cm
+			)?;
+		}
+
+		Ok(())
+	}
+
+	fn non_zero_constraints<CS: ConstraintSystem>(&self, cs: &mut CS) -> Result<(), R1CSError> {
+		for i in 0..2 {
+			let elt = if i == 0 { &self.inputs } else { &self.outputs };
+			for i in 0..elt.len() {
+				// verify amounts are non-zero
+				is_nonzero_gadget(cs, elt[i].value, elt[i].inv_value)?;
+			}
+		}
+
+		Ok(())
+	}
+
+	fn input_amount(&self) -> LinearCombination {
+		let mut sum_inputs = LinearCombination::from(Scalar::zero());
+		for i in 0..self.inputs.len() {
+			sum_inputs = sum_inputs + self.inputs[i].value.variable;
+		}
+
+		sum_inputs
+	}
+
+	fn output_amount(&self) -> LinearCombination {
+		let mut sum_outputs = LinearCombination::from(Scalar::zero());
+		for i in 0..self.outputs.len() {
+			sum_outputs = sum_outputs + self.outputs[i].value.variable;
+		}
+
+		sum_outputs
+	}
+}
+
+pub fn transaction_preimage_gadget<CS: ConstraintSystem>(
+	cs: &mut CS,
+	transactions: Vec<Transaction>,
+	poseidon_params: &Poseidon
+) -> Result<(), R1CSError> {
+	let mut sum_inputs = LinearCombination::from(Scalar::zero());
+	let mut sum_outputs = LinearCombination::from(Scalar::zero());
+
+	// each individual transaction has to be valid w.r.t its own inputs/outputs
+	for i in 0..transactions.len() {
+		let tx = &transactions[i];
+		tx.hash_constraints(cs, poseidon_params)?;
+		tx.non_zero_constraints(cs)?;		
+
+		sum_inputs = sum_inputs + tx.input_amount();
+		sum_outputs = sum_outputs + tx.output_amount();
+	}
+
+	// total inputs and outputs should be equal and the difference should be zero
+	cs.constrain(sum_inputs - sum_outputs);
+	Ok(())
+}

--- a/gadgets/src/transaction/tests.rs
+++ b/gadgets/src/transaction/tests.rs
@@ -1,0 +1,296 @@
+use crate::poseidon::Poseidon_hash_4;
+use crate::poseidon::Poseidon_hash_2;
+use crate::poseidon::allocate_statics_for_verifier;
+use crate::poseidon::allocate_statics_for_prover;
+use crate::transaction::Transaction;
+use crate::transaction::AllocatedCoin;
+
+use crate::poseidon::PoseidonBuilder;
+use crate::poseidon::builder::Poseidon;
+use crate::poseidon::PoseidonSbox;
+use crate::transaction::transaction_preimage_gadget;
+
+use crate::utils::AllocatedScalar;
+
+use crate::poseidon::builder::gen_round_keys;
+use crate::poseidon::builder::gen_mds_matrix;
+use curve25519_dalek::scalar::Scalar;
+use bulletproofs::r1cs::{Prover, Verifier};
+use bulletproofs::{BulletproofGens, PedersenGens};
+use merlin::Transcript;
+
+#[cfg(feature="std")]
+use std::time::{Instant};
+
+#[cfg(feature="std")]
+use rand::SeedableRng;
+
+#[cfg(feature="std")]
+use rand::rngs::StdRng;
+
+#[cfg(feature="std")]
+fn get_poseidon_params(sbox: Option<PoseidonSbox>) -> Poseidon{
+	let width = 6;
+	let (full_b, full_e) = (4, 4);
+	let partial_rounds = 57;
+
+	let sbox = sbox.unwrap_or_else(|| PoseidonSbox::Inverse);
+
+	PoseidonBuilder::new(width)
+		.num_rounds(full_b, full_e, partial_rounds)
+		.round_keys(gen_round_keys(width, full_b + full_e + partial_rounds))
+		.mds_matrix(gen_mds_matrix(width))
+		.sbox(sbox)
+		.build()
+}
+
+#[test]
+fn test_is_valid_transaction_spend() {
+	let params = get_poseidon_params(Some(PoseidonSbox::Exponentiation3));
+	let pc_gens = PedersenGens::default();
+	let bp_gens = BulletproofGens::new(4096, 1);
+
+	let mut test_rng: StdRng = SeedableRng::from_seed([24u8; 32]);
+
+	let input = Scalar::from(10u32);
+	let input_inverse = input.invert();
+	let input_rho = Scalar::random(&mut test_rng);
+	let input_r = Scalar::random(&mut test_rng);
+	let input_nullifier = Scalar::random(&mut test_rng);
+	let input_sn = Poseidon_hash_2(input_r, input_nullifier, &params);
+	let input_cm = Poseidon_hash_4([input, input_rho, input_r, input_nullifier], &params);
+
+	let output_1 = Scalar::from(5u32);
+	let output_1_inverse = Scalar::from(5u32).invert();
+	let output_1_rho = Scalar::random(&mut test_rng);
+	let output_1_r = Scalar::random(&mut test_rng);
+	let output_1_nullifier = Scalar::random(&mut test_rng);
+	let output_1_sn = Poseidon_hash_2(output_1_r, output_1_nullifier, &params);
+	let output_1_cm = Poseidon_hash_4([output_1, output_1_rho, output_1_r, output_1_nullifier], &params);
+
+	let output_2 = Scalar::from(5u32);
+	let output_2_inverse = Scalar::from(5u32).invert();
+	let output_2_rho = Scalar::random(&mut test_rng);
+	let output_2_r = Scalar::random(&mut test_rng);
+	let output_2_nullifier = Scalar::random(&mut test_rng);
+	let output_2_sn = Poseidon_hash_2(output_2_r, output_2_nullifier, &params);
+	let output_2_cm = Poseidon_hash_4([output_2, output_2_rho, output_2_r, output_2_nullifier], &params);
+
+	{
+		let (proof, commitments) = {
+			let mut coms = vec![];
+
+			let mut prover_transcript = Transcript::new(b"Transaction");
+			let mut prover = Prover::new(&pc_gens, &mut prover_transcript);
+
+			let (com_input_inverse_val, var_input_inverse_val) = prover.commit(input_inverse.clone(), Scalar::random(&mut test_rng));
+			let alloc_input_inverse_val = AllocatedScalar {
+				variable: var_input_inverse_val,
+				assignment: Some(input_inverse),
+			};
+			coms.push(com_input_inverse_val);
+			let (com_input_val, var_input_val) = prover.commit(input.clone(), Scalar::random(&mut test_rng));
+			let alloc_input_val = AllocatedScalar {
+				variable: var_input_val,
+				assignment: Some(input),
+			};
+			coms.push(com_input_val);
+			let (com_input_rho, var_input_rho) = prover.commit(input_rho.clone(), Scalar::random(&mut test_rng));
+			let alloc_input_rho = AllocatedScalar {
+				variable: var_input_rho,
+				assignment: Some(input_rho),
+			};
+			coms.push(com_input_rho);
+			let (com_input_r, var_input_r) = prover.commit(input_r.clone(), Scalar::random(&mut test_rng));
+			let alloc_input_r = AllocatedScalar {
+				variable: var_input_r,
+				assignment: Some(input_r),
+			};
+			coms.push(com_input_r);
+			let (com_input_nullifier, var_input_nullifier) = prover.commit(input_nullifier.clone(), Scalar::random(&mut test_rng));
+			let alloc_input_nullifier = AllocatedScalar {
+				variable: var_input_nullifier,
+				assignment: Some(input_nullifier),
+			};
+			coms.push(com_input_nullifier);
+			let coin = AllocatedCoin::new(
+				alloc_input_inverse_val,
+				alloc_input_val,
+				alloc_input_rho,
+				alloc_input_r,
+				alloc_input_nullifier,
+				input_sn,
+				input_cm,
+			);
+
+			let (com_output_1_inverse_val, var_output_1_inverse_val) = prover.commit(output_1_inverse.clone(), Scalar::random(&mut test_rng));
+			let alloc_output_1_inverse_val = AllocatedScalar {
+				variable: var_output_1_inverse_val,
+				assignment: Some(output_1_inverse),
+			};
+			coms.push(com_output_1_inverse_val);
+			let (com_output_1_val, var_output_1_val) = prover.commit(output_1.clone(), Scalar::random(&mut test_rng));
+			let alloc_output_1_val = AllocatedScalar {
+				variable: var_output_1_val,
+				assignment: Some(output_1),
+			};
+			coms.push(com_output_1_val);
+			let (com_output_1_rho, var_output_1_rho) = prover.commit(output_1_rho.clone(), Scalar::random(&mut test_rng));
+			let alloc_output_1_rho = AllocatedScalar {
+				variable: var_output_1_rho,
+				assignment: Some(output_1_rho),
+			};
+			coms.push(com_output_1_rho);
+			let (com_output_1_r, var_output_1_r) = prover.commit(output_1_r.clone(), Scalar::random(&mut test_rng));
+			let alloc_output_1_r = AllocatedScalar {
+				variable: var_output_1_r,
+				assignment: Some(output_1_r),
+			};
+			coms.push(com_output_1_r);
+			let (com_output_1_nullifier, var_output_1_nullifier) = prover.commit(output_1_nullifier.clone(), Scalar::random(&mut test_rng));
+			let alloc_output_1_nullifier = AllocatedScalar {
+				variable: var_output_1_nullifier,
+				assignment: Some(output_1_nullifier),
+			};
+			coms.push(com_output_1_nullifier);
+
+			let output_coin_1 = AllocatedCoin::new(
+				alloc_output_1_inverse_val,
+				alloc_output_1_val,
+				alloc_output_1_rho,
+				alloc_output_1_r,
+				alloc_output_1_nullifier,
+				output_1_sn,
+				output_1_cm,
+			);
+
+			let (com_output_2_inverse_val, var_output_2_inverse_val) = prover.commit(output_2_inverse.clone(), Scalar::random(&mut test_rng));
+			let alloc_output_2_inverse_val = AllocatedScalar {
+				variable: var_output_2_inverse_val,
+				assignment: Some(output_2_inverse),
+			};
+			coms.push(com_output_2_inverse_val);
+			let (com_output_2_val, var_output_2_val) = prover.commit(output_2.clone(), Scalar::random(&mut test_rng));
+			let alloc_output_2_val = AllocatedScalar {
+				variable: var_output_2_val,
+				assignment: Some(output_2),
+			};
+			coms.push(com_output_2_val);
+			let (com_output_2_rho, var_output_2_rho) = prover.commit(output_2_rho.clone(), Scalar::random(&mut test_rng));
+			let alloc_output_2_rho = AllocatedScalar {
+				variable: var_output_2_rho,
+				assignment: Some(output_2_rho),
+			};
+			coms.push(com_output_2_rho);
+			let (com_output_2_r, var_output_1_r) = prover.commit(output_2_r.clone(), Scalar::random(&mut test_rng));
+			let alloc_output_2_r = AllocatedScalar {
+				variable: var_output_1_r,
+				assignment: Some(output_1_r),
+			};
+			coms.push(com_output_2_r);
+			let (com_output_2_nullifier, var_output_2_nullifier) = prover.commit(output_2_nullifier.clone(), Scalar::random(&mut test_rng));
+			let alloc_output_2_nullifier = AllocatedScalar {
+				variable: var_output_2_nullifier,
+				assignment: Some(output_2_nullifier),
+			};
+			coms.push(com_output_2_nullifier);
+
+			let output_coin_2 = AllocatedCoin::new(
+				alloc_output_2_inverse_val,
+				alloc_output_2_val,
+				alloc_output_2_rho,
+				alloc_output_2_r,
+				alloc_output_2_nullifier,
+				output_2_sn,
+				output_2_cm,
+			);
+
+			let num_statics = 4;
+			let statics_2 = allocate_statics_for_prover(&mut prover, num_statics);
+
+			let num_statics = 2;
+			let statics_4 = allocate_statics_for_prover(&mut prover, num_statics);
+
+			let transaction = Transaction {
+				inputs: vec![coin],
+				outputs: vec![output_coin_1, output_coin_2],
+				statics_2,
+				statics_4,
+			};
+
+			let start = Instant::now();
+			assert!(transaction_preimage_gadget(
+				&mut prover,
+				vec![transaction],
+				&params
+			).is_ok());
+
+			let proof = prover.prove_with_rng(&bp_gens, &mut test_rng).unwrap();
+
+			let end = start.elapsed();
+
+			println!("Proving time is {:?}", end);
+			(proof, coms)
+		};
+
+		let mut verifier_transcript = Transcript::new(b"TransactionTest");
+		let mut verifier = Verifier::new(&mut verifier_transcript);
+		let mut allocs = vec![];
+		for i in 0..commitments.len() {
+			let v = verifier.commit(commitments[i]);
+			allocs.push(AllocatedScalar {
+				variable: v,
+				assignment: None,
+			});
+		}
+
+		let num_statics = 4;
+		let statics_2 = allocate_statics_for_verifier(&mut verifier, num_statics, &pc_gens);
+
+		let num_statics = 2;
+		let statics_4 = allocate_statics_for_verifier(&mut verifier, num_statics, &pc_gens);
+
+		let transaction = Transaction {
+			inputs: vec![AllocatedCoin::new(
+				allocs[0],
+				allocs[1],
+				allocs[2],
+				allocs[3],
+				allocs[4],
+				input_sn,
+				input_cm,
+			)],
+			outputs: vec![AllocatedCoin::new(
+				allocs[5],
+				allocs[6],
+				allocs[7],
+				allocs[8],
+				allocs[9],
+				output_1_sn,
+				output_1_cm,
+			), AllocatedCoin::new(
+				allocs[10],
+				allocs[11],
+				allocs[12],
+				allocs[13],
+				allocs[14],
+				output_2_sn,
+				output_2_cm,
+			)],
+			statics_2,
+			statics_4,
+		};
+
+		let start = Instant::now();
+		assert!(transaction_preimage_gadget(
+			&mut verifier,
+			vec![transaction],
+			&params
+		).is_ok());
+
+		assert!(verifier.verify_with_rng(&proof, &pc_gens, &bp_gens, &mut test_rng).is_ok());
+		let end = start.elapsed();
+
+		println!("Verification time is {:?}", end);
+	}
+}

--- a/gadgets/src/transaction/tests.rs
+++ b/gadgets/src/transaction/tests.rs
@@ -233,7 +233,7 @@ fn test_is_valid_transaction_spend() {
 			(proof, coms)
 		};
 
-		let mut verifier_transcript = Transcript::new(b"TransactionTest");
+		let mut verifier_transcript = Transcript::new(b"Transaction");
 		let mut verifier = Verifier::new(&mut verifier_transcript);
 		let mut allocs = vec![];
 		for i in 0..commitments.len() {

--- a/gadgets/src/zero_nonzero/tests.rs
+++ b/gadgets/src/zero_nonzero/tests.rs
@@ -1,4 +1,6 @@
 use super::*;
+use bulletproofs::r1cs::{Prover, Verifier};
+use bulletproofs::{BulletproofGens, PedersenGens};
 use merlin::Transcript;
 
 #[test]

--- a/pallets/merkle/Cargo.toml
+++ b/pallets/merkle/Cargo.toml
@@ -33,7 +33,7 @@ sp-runtime = { default-features = false, version = "2.0.0", git = "https://githu
 merlin = { version = "2.0.0", default-features = false }
 sha2 = { version = "0.9.1", default-features = false }
 rand_core = { version = "0.5", default-features = false, features = ["alloc", "getrandom"] }
-bulletproofs = { version = "2.0.0", rev = "553863b", git = "https://github.com/edgeware-builders/bulletproofs", default-features = false, features = ["yoloproofs"] }
+bulletproofs = { version = "2.0.0", rev = "160c9ab", git = "https://github.com/edgeware-builders/bulletproofs", default-features = false, features = ["yoloproofs"] }
 rand = { version = "0.7", optional = true }
 
 [dev-dependencies]

--- a/pallets/merkle/src/mock.rs
+++ b/pallets/merkle/src/mock.rs
@@ -1,5 +1,5 @@
-use crate::{Module, Config};
-use frame_support::{impl_outer_origin, impl_outer_event, parameter_types, weights::Weight};
+use crate::{Config, Module};
+use frame_support::{impl_outer_event, impl_outer_origin, parameter_types, weights::Weight};
 use frame_system as system;
 use sp_core::H256;
 use sp_runtime::{
@@ -58,9 +58,11 @@ impl frame_system::Config for Test {
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type SystemWeightInfo = ();
+	type SS58Prefix = Prefix;
 }
 
 parameter_types! {
+	pub Prefix: u8 = 100;
 	pub const ExistentialDeposit: Balance = 0;
 	pub const MaxLocks: u32 = 50;
 	pub const MaxTreeDepth: u8 = 32;

--- a/pallets/mixer/Cargo.toml
+++ b/pallets/mixer/Cargo.toml
@@ -36,7 +36,7 @@ rand = { version = "0.7", optional = true }
 
 [dev-dependencies]
 merlin = { version = "2.0.0", default-features = false }
-bulletproofs = { version = "2.0.0", rev = "9ed295f", git = "https://github.com/edgeware-builders/bulletproofs", default-features = false, features = ["yoloproofs"] }
+bulletproofs = { version = "2.0.0", rev = "160c9ab", git = "https://github.com/edgeware-builders/bulletproofs", default-features = false, features = ["yoloproofs"] }
 sp-core = { default-features = false, version = '2.0.0', git = "https://github.com/paritytech/substrate.git" }
 sp-io = { default-features = false, version = '2.0.0', git = "https://github.com/paritytech/substrate.git" }
 

--- a/pallets/mixer/src/mock.rs
+++ b/pallets/mixer/src/mock.rs
@@ -1,8 +1,8 @@
-use sp_runtime::ModuleId;
-use crate::{Module, Config};
-use frame_support::{impl_outer_origin, impl_outer_event, parameter_types, weights::Weight};
+use crate::{Config, Module};
+use frame_support::{impl_outer_event, impl_outer_origin, parameter_types, weights::Weight};
 use frame_system as system;
 use sp_core::H256;
+use sp_runtime::ModuleId;
 use sp_runtime::{
 	testing::Header,
 	traits::{BlakeTwo256, IdentityLookup},
@@ -32,6 +32,7 @@ impl_outer_origin! {
 #[derive(Clone, Eq, PartialEq)]
 pub struct Test;
 parameter_types! {
+	pub Prefix: u8 = 100;
 	pub const BlockHashCount: u64 = 250;
 	pub const MaximumBlockWeight: Weight = 1024;
 	pub const MaximumBlockLength: u32 = 2 * 1024;
@@ -60,6 +61,7 @@ impl frame_system::Config for Test {
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type SystemWeightInfo = ();
+	type SS58Prefix = Prefix;
 }
 
 parameter_types! {
@@ -108,15 +110,15 @@ pub type Mixer = Module<Test>;
 
 // Build genesis storage according to the mock runtime.
 pub fn new_test_ext() -> sp_io::TestExternalities {
-	use balances::{GenesisConfig as BalancesConfig};
-	let mut t = frame_system::GenesisConfig::default().build_storage::<Test>().unwrap();
-	BalancesConfig::<Test>{
+	use balances::GenesisConfig as BalancesConfig;
+	let mut t = frame_system::GenesisConfig::default()
+		.build_storage::<Test>()
+		.unwrap();
+	BalancesConfig::<Test> {
 		// Total issuance will be 200 with treasury account initialized at ED.
-		balances: vec![
-			(0, 1_000_000_000),
-			(1, 1_000_000_000),
-			(2, 1_000_000_000),
-		],
-	}.assimilate_storage(&mut t).unwrap();
+		balances: vec![(0, 1_000_000_000), (1, 1_000_000_000), (2, 1_000_000_000)],
+	}
+	.assimilate_storage(&mut t)
+	.unwrap();
 	t.into()
 }

--- a/pallets/mixer/src/tests.rs
+++ b/pallets/mixer/src/tests.rs
@@ -1,14 +1,14 @@
+use crate::mock::*;
 use bulletproofs::r1cs::LinearCombination;
-use rand::rngs::ThreadRng;
-use sp_runtime::DispatchError;
+use bulletproofs::r1cs::{ConstraintSystem, Prover};
+use bulletproofs::{BulletproofGens, PedersenGens};
 use curve25519_dalek::scalar::Scalar;
 use merkle::merkle::hasher::Hasher;
 use merkle::merkle::helper::{commit_leaf, commit_path_level, leaf_data};
 use merkle::merkle::keys::{Commitment, Data};
 use merkle::merkle::poseidon::Poseidon;
-use crate::mock::*;
-use bulletproofs::r1cs::{ConstraintSystem, Prover};
-use bulletproofs::{BulletproofGens, PedersenGens};
+use rand::rngs::ThreadRng;
+use sp_runtime::DispatchError;
 
 use frame_support::{assert_err, assert_ok};
 use merlin::Transcript;
@@ -63,7 +63,7 @@ fn should_fail_to_deposit_with_insufficient_balance() {
 				Mixer::deposit(Origin::signed(4), i, vec![leaf]),
 				DispatchError::Module {
 					index: 0,
-					error: 6,
+					error: 4,
 					message: Some("InsufficientBalance")
 				}
 			);

--- a/runtime/src/lib.rs
+++ b/runtime/src/lib.rs
@@ -5,21 +5,20 @@
 // Make the WASM binary available.
 #[cfg(feature = "std")]
 include!(concat!(env!("OUT_DIR"), "/wasm_binary.rs"));
-use sp_runtime::ModuleId;
 use pallet_grandpa::fg_primitives;
 use pallet_grandpa::{AuthorityId as GrandpaId, AuthorityList as GrandpaAuthorityList};
+pub use pallet_transaction_payment::{CurrencyAdapter, Multiplier, TargetedFeeAdjustment};
 use sp_api::impl_runtime_apis;
 use sp_consensus_aura::sr25519::AuthorityId as AuraId;
 use sp_core::{crypto::KeyTypeId, OpaqueMetadata};
 use sp_runtime::traits::{
-	BlakeTwo256, Block as BlockT, IdentifyAccount, IdentityLookup, NumberFor, Verify
+	BlakeTwo256, Block as BlockT, IdentifyAccount, IdentityLookup, NumberFor, Verify,
 };
-pub use pallet_transaction_payment::{Multiplier, TargetedFeeAdjustment, CurrencyAdapter};
+use sp_runtime::ModuleId;
 use sp_runtime::{
-	Perbill, Perquintill, FixedPointNumber,
 	create_runtime_str, generic, impl_opaque_keys,
 	transaction_validity::{TransactionSource, TransactionValidity},
-	ApplyExtrinsicResult, MultiSignature,
+	ApplyExtrinsicResult, FixedPointNumber, MultiSignature, Perbill, Perquintill,
 };
 use sp_std::prelude::*;
 #[cfg(feature = "std")]
@@ -31,16 +30,16 @@ use static_assertions::const_assert;
 pub use frame_support::{
 	construct_runtime, parameter_types,
 	traits::{
-		Currency, Imbalance, KeyOwnerProofSystem, OnUnbalanced, Randomness, LockIdentifier,
+		Currency, Imbalance, KeyOwnerProofSystem, LockIdentifier, OnUnbalanced, Randomness,
 		U128CurrencyToVote,
 	},
 	weights::{
 		constants::{BlockExecutionWeight, ExtrinsicBaseWeight, RocksDbWeight, WEIGHT_PER_SECOND},
-		IdentityFee, Weight, DispatchClass,
+		DispatchClass, IdentityFee, Weight,
 	},
 	StorageValue,
 };
-pub use frame_system::limits::{BlockWeights, BlockLength};
+pub use frame_system::limits::{BlockLength, BlockWeights};
 pub use pallet_balances::Call as BalancesCall;
 pub use pallet_timestamp::Call as TimestampCall;
 #[cfg(any(feature = "std", test))]
@@ -50,7 +49,7 @@ pub mod currency {
 	use super::Balance;
 
 	pub const MILLICENTS: Balance = 1_000_000_000;
-	pub const CENTS: Balance = 1_000 * MILLICENTS;    // assume this is worth about a cent.
+	pub const CENTS: Balance = 1_000 * MILLICENTS; // assume this is worth about a cent.
 	pub const DOLLARS: Balance = 100 * CENTS;
 
 	pub const fn deposit(items: u32, bytes: u32) -> Balance {
@@ -61,9 +60,9 @@ pub mod currency {
 use currency::*;
 
 /// Importing a groups pallet
-pub use mixer;
-/// Importing a groups pallet
 pub use merkle;
+/// Importing a groups pallet
+pub use mixer;
 
 /// An index to a block.
 pub type BlockNumber = u32;
@@ -153,6 +152,7 @@ const NORMAL_DISPATCH_RATIO: Perbill = Perbill::from_percent(75);
 const MAXIMUM_BLOCK_WEIGHT: Weight = 2 * WEIGHT_PER_SECOND;
 
 parameter_types! {
+	pub Prefix: u8 = 100;
 	pub const BlockHashCount: BlockNumber = 2400;
 	pub const Version: RuntimeVersion = VERSION;
 	pub RuntimeBlockLength: BlockLength =
@@ -201,6 +201,7 @@ impl frame_system::Config for Runtime {
 	type OnNewAccount = ();
 	type OnKilledAccount = ();
 	type SystemWeightInfo = frame_system::weights::SubstrateWeight<Runtime>;
+	type SS58Prefix = Prefix;
 }
 
 impl pallet_aura::Config for Runtime {
@@ -300,7 +301,6 @@ impl mixer::Config for Runtime {
 	type MaxTreeDepth = MaxTreeDepth;
 	type DepositLength = MinimumDepositLength;
 }
-
 
 // Create the runtime by composing the FRAME pallets that were previously configured.
 construct_runtime!(


### PR DESCRIPTION
This adds a transaction gadget which defines a spend of a set input and output coins. The constraints being checked are that:
- serial numbers are properly hashed
- commitments are properly hashed
- input amounts equal output amounts
- all amounts are non-zero

The purpose of this gadget is to fit into more complex MT structures such as tree where leaves define a coin with a variable value.